### PR TITLE
add github actions to build in ci

### DIFF
--- a/.github/workflows/pio-run.yml
+++ b/.github/workflows/pio-run.yml
@@ -1,0 +1,25 @@
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pio-env:
+          - esp32dev
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Build PlatformIO Project
+        run: pio run -e ${{ matrix.pio-env }}


### PR DESCRIPTION
Hello @Berational91 

I have been playing with this project over the weekend.  I have some changes to support building/debugging in a native linux x86_64 environment that I would like to submit PRs for, but I thought I'd submit this one first to enable CI so you can see the impact on the build for ESP32 and to be able to add the CI variation for native to the matrix once I'm ready to submit it.

The native/linux work is mostly something to do while I wait for my ttgo board to be delivered, but I think it will have some ongoing utility for development and debugging.