### PR TITLE
add pio environment to allow uploading to a lilygo ttgo without editing tft_espi user setup

### DIFF
--- a/.github/workflows/pio-run.yml
+++ b/.github/workflows/pio-run.yml
@@ -1,0 +1,26 @@
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pio-env:
+          - esp32dev
+          - esp32dev-ttgo
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Build PlatformIO Project
+        run: pio run -e ${{ matrix.pio-env }}

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,3 +15,37 @@ framework = arduino
 lib_deps = bodmer/TFT_eSPI@^2.5.31
 monitor_speed = 115200
 board_build.flash_mode = dio
+
+
+[env:esp32dev-ttgo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps = bodmer/TFT_eSPI@^2.5.31
+monitor_speed = 115200
+board_build.flash_mode = dio
+build_flags = ; converted from TFT_eSPI/User_Setups/Setup25_TTGO_T_Display.h
+    -D USER_SETUP_LOADED
+    -D USER_SETUP_ID=25
+    -D ST7789_DRIVER
+    -D TFT_SDA_READ
+    -D TFT_WIDTH=135
+    -D TFT_HEIGHT=240
+    -D CGRAM_OFFSET
+    -D TFT_MOSI=19
+    -D TFT_SCLK=18
+    -D TFT_CS=5
+    -D TFT_DC=16
+    -D TFT_RST=23
+    -D TFT_BL=4
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D LOAD_GLCD
+    -D LOAD_FONT2
+    -D LOAD_FONT4
+    -D LOAD_FONT6
+    -D LOAD_FONT7
+    -D LOAD_FONT8
+    -D LOAD_GFXFF
+    -D SMOOTH_FONT
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=6000000


### PR DESCRIPTION
Follows #8 

Adds a pio environment specifically for the lilygo ttgo board where you don't have to modify the user setup i the tft espe library along with extending the ci build matrix to build the new environment